### PR TITLE
Add Refresh Tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/GlobalExceptionHandler.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.NoSuchElementException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -15,35 +16,42 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException exception) {
         return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(exception.getMessage());
+                .status(HttpStatus.CONFLICT)
+                .body(exception.getMessage());
     }
 
     @ExceptionHandler(ExistingEmailException.class)
     public ResponseEntity<String> handleExistingEmailException(ExistingEmailException exception) {
         return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(exception.getMessage());
+                .status(HttpStatus.CONFLICT)
+                .body(exception.getMessage());
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<String> handleBadCredentialsException(BadCredentialsException exception) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(exception.getMessage());
     }
 
     @ExceptionHandler(DuplicateKeyException.class)
     public ResponseEntity<String> handleDuplicateKeyException(DuplicateKeyException exception) {
         return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(exception.getMessage());
+                .status(HttpStatus.CONFLICT)
+                .body(exception.getMessage());
     }
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException exception) {
         return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(exception.getMessage());
+                .status(HttpStatus.CONFLICT)
+                .body(exception.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleGenericException(Exception exception) {
         return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body("An unexpected error occured: " + exception.getMessage());
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("An unexpected error occured: " + exception.getMessage());
     }
 }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/JwtAuthenticationFilter.java
@@ -21,17 +21,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @Component
-public class JwtAuthenticationFilter extends OncePerRequestFilter{
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final HandlerExceptionResolver handlerExceptionResolver;
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
 
     public JwtAuthenticationFilter(
-        JwtService jwtService,
-        UserDetailsService userDetailsService,
-        HandlerExceptionResolver handlerExceptionResolver
-    ) {
+            JwtService jwtService,
+            UserDetailsService userDetailsService,
+            HandlerExceptionResolver handlerExceptionResolver) {
         this.jwtService = jwtService;
         this.userDetailsService = userDetailsService;
         this.handlerExceptionResolver = handlerExceptionResolver;
@@ -39,10 +38,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter{
 
     @Override
     protected void doFilterInternal(
-        @NonNull HttpServletRequest request, 
-        @NonNull HttpServletResponse response, 
-        @NonNull FilterChain filterChain
-    ) throws ServletException, IOException {
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
         final String idToken = CookieService.getCookieValue(request, "id_token");
 
         try {
@@ -51,7 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter{
                 filterChain.doFilter(request, response);
                 return;
             }
-            
+
             final String email = jwtService.extractClaim(idToken, "email");
             UserDetails userDetails = this.userDetailsService.loadUserByUsername(email);
 
@@ -63,10 +61,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter{
             }
 
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.getAuthorities()
-            );
+                    userDetails,
+                    null,
+                    userDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authToken);
 
             filterChain.doFilter(request, response);

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/JwtAuthenticationFilter.java
@@ -22,17 +22,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @Component
-public class JwtAuthenticationFilter extends OncePerRequestFilter{
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final HandlerExceptionResolver handlerExceptionResolver;
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
 
     public JwtAuthenticationFilter(
-        JwtService jwtService,
-        UserDetailsService userDetailsService,
-        HandlerExceptionResolver handlerExceptionResolver
-    ) {
+            JwtService jwtService,
+            UserDetailsService userDetailsService,
+            HandlerExceptionResolver handlerExceptionResolver) {
         this.jwtService = jwtService;
         this.userDetailsService = userDetailsService;
         this.handlerExceptionResolver = handlerExceptionResolver;
@@ -40,10 +39,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter{
 
     @Override
     protected void doFilterInternal(
-        @NonNull HttpServletRequest request, 
-        @NonNull HttpServletResponse response, 
-        @NonNull FilterChain filterChain
-    ) throws ServletException, IOException {
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
         final String idToken = CookieService.getCookieValue(request, "id_token");
 
         try {
@@ -52,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter{
                 filterChain.doFilter(request, response);
                 return;
             }
-            
+
             final String email = jwtService.extractClaim(idToken, "email");
             UserDetails userDetails = this.userDetailsService.loadUserByUsername(email);
 
@@ -64,10 +62,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter{
             }
 
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.getAuthorities()
-            );
+                    userDetails,
+                    null,
+                    userDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authToken);
 
             filterChain.doFilter(request, response);

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/JwtDecoderConfig.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/JwtDecoderConfig.java
@@ -11,10 +11,18 @@ public class JwtDecoderConfig {
     @Value("${jwt.secret.key}")
     private String jwtSecret;
 
+    @Value("${refresh.secret.key}")
+    private String refreshSecret;
+
     private final JwtDecoderFactory jwtDecoderFactory;
 
     public JwtDecoderConfig(JwtDecoderFactory jwtDecoderFactory) {
         this.jwtDecoderFactory = jwtDecoderFactory;
+    }
+
+    @Bean
+    public NimbusJwtDecoder refreshDecoder() {
+        return jwtDecoderFactory.withSecretKey(refreshSecret);
     }
 
     @Bean
@@ -29,6 +37,7 @@ public class JwtDecoderConfig {
 
     // @Bean
     // public NimbusJwtDecoder githubJwtDecoder() {
-    //     return jwtDecoderFactory.createDecoder("https://github.com/login/oauth/certs");
+    // return
+    // jwtDecoderFactory.createDecoder("https://github.com/login/oauth/certs");
     // }
 }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/RedisConfig.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/RedisConfig.java
@@ -9,10 +9,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
 public class RedisConfig {
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
     @Bean

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/RedisConfig.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.kennan.mp3player.mp3_player_api.configs;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/SecurityConfiguration.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/SecurityConfiguration.java
@@ -32,6 +32,7 @@ public class SecurityConfiguration {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
+            .logout(logout -> logout.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/configs/SecurityConfiguration.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/configs/SecurityConfiguration.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -21,9 +22,8 @@ public class SecurityConfiguration {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     public SecurityConfiguration(
-        JwtAuthenticationFilter jwtAuthenticationFilter,
-        AuthenticationProvider authenticationProvider
-    ) {
+            JwtAuthenticationFilter jwtAuthenticationFilter,
+            AuthenticationProvider authenticationProvider) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.authenticationProvider = authenticationProvider;
     }
@@ -31,17 +31,18 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable())
-            .logout(logout -> logout.disable())
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**").permitAll()
-                .anyRequest().authenticated()
-            )
-            .sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            )
-            .authenticationProvider(authenticationProvider)
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .logout(logout -> logout.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider)
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -50,9 +51,10 @@ public class SecurityConfiguration {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of("http://localhost:8081"));
-        configuration.setAllowedMethods(List.of("GET", "POST"));
-        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
+        configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationController.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationController.java
@@ -54,13 +54,17 @@ public class AuthenticationController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<User> authenticate(@RequestBody LoginUserDTO loginUserDTO, HttpServletResponse response) {
+    public ResponseEntity<User> authenticate(@RequestBody LoginUserDTO loginUserDTO, HttpServletResponse response,
+            HttpServletRequest request) {
         User authenticatedUser = authenticationService.authenticate(loginUserDTO);
+        boolean withRefreshToken = request.getParameter("refresh") != null;
 
         String jwtToken = jwtService.generateToken(authenticatedUser);
-        String refreshToken = refreshService.generateToken(authenticatedUser);
+        if (withRefreshToken) {
+            String refreshToken = refreshService.generateToken(authenticatedUser);
+            CookieService.setHttpOnlyCookie(refreshToken, "refresh_token", response);
+        }
         CookieService.setHttpOnlyCookie(jwtToken, "id_token", response);
-        CookieService.setHttpOnlyCookie(refreshToken, "refresh_token", response);
 
         return ResponseEntity.ok(authenticatedUser);
     }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationController.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationController.java
@@ -108,7 +108,7 @@ public class AuthenticationController {
         }
     }
 
-    @GetMapping("/refresh")
+    @PostMapping("/refresh")
     public void refreshIdToken(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = CookieService.getCookieValue(request, "refresh_token");
         String idToken = CookieService.getCookieValue(request, "id_token");

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationController.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationController.java
@@ -57,7 +57,9 @@ public class AuthenticationController {
         User authenticatedUser = authenticationService.authenticate(loginUserDTO);
 
         String jwtToken = jwtService.generateToken(authenticatedUser);
+        String refreshToken = refreshService.generateToken(authenticatedUser);
         CookieService.setHttpOnlyCookie(jwtToken, "id_token", response);
+        CookieService.setHttpOnlyCookie(refreshToken, "refresh_token", response);
 
         return ResponseEntity.ok(authenticatedUser);
     }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/LogoutController.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/LogoutController.java
@@ -1,0 +1,33 @@
+package com.kennan.mp3player.mp3_player_api.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kennan.mp3player.mp3_player_api.service.CookieService;
+import com.kennan.mp3player.mp3_player_api.service.JwtService;
+import com.kennan.mp3player.mp3_player_api.service.OAuthService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@RestController
+public class LogoutController {
+    private final JwtService jwtService;
+
+    public LogoutController(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+        String idToken = CookieService.getCookieValue(request, "id_token");
+
+        jwtService.blacklistToken(idToken);
+
+        CookieService.removeHttpOnlyCookie("id_token", response);
+        CookieService.removeHttpOnlyCookie("refresh_token", response);
+
+        return ResponseEntity.ok("Logged out successfully");
+    }
+}

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/LogoutController.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/LogoutController.java
@@ -1,23 +1,30 @@
 package com.kennan.mp3player.mp3_player_api.controllers;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kennan.mp3player.mp3_player_api.service.AuthenticationService;
 import com.kennan.mp3player.mp3_player_api.service.CookieService;
 import com.kennan.mp3player.mp3_player_api.service.JwtService;
-import com.kennan.mp3player.mp3_player_api.service.OAuthService;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @RestController
 public class LogoutController {
     private final AuthenticationService authenticationService;
+    private final JwtService jwtService;
+    private final UserDetailsService userDetailsService;
 
-    public LogoutController(AuthenticationService authenticationService) {
+    public LogoutController(AuthenticationService authenticationService, JwtService jwtService,
+            UserDetailsService userDetailsService) {
         this.authenticationService = authenticationService;
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
     }
 
     @PostMapping("/logout")
@@ -25,5 +32,20 @@ public class LogoutController {
         authenticationService.terminateSession(request, response, true);
 
         return ResponseEntity.ok("Logged out successfully");
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getUser(HttpServletRequest request) {
+        String idToken = CookieService.getCookieValue(request, "id_token");
+        try {
+            final String email = jwtService.extractClaim(idToken, "email");
+            UserDetails userDetails = this.userDetailsService.loadUserByUsername(email);
+            if (!jwtService.isTokenValid(idToken, userDetails)) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Token is invalid");
+            }
+            return ResponseEntity.ok(userDetails);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Token is invalid");
+        }
     }
 }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/LogoutController.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/controllers/LogoutController.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kennan.mp3player.mp3_player_api.service.AuthenticationService;
 import com.kennan.mp3player.mp3_player_api.service.CookieService;
 import com.kennan.mp3player.mp3_player_api.service.JwtService;
 import com.kennan.mp3player.mp3_player_api.service.OAuthService;
@@ -13,20 +14,15 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @RestController
 public class LogoutController {
-    private final JwtService jwtService;
+    private final AuthenticationService authenticationService;
 
-    public LogoutController(JwtService jwtService) {
-        this.jwtService = jwtService;
+    public LogoutController(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
     }
 
     @PostMapping("/logout")
     public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
-        String idToken = CookieService.getCookieValue(request, "id_token");
-
-        jwtService.blacklistToken(idToken);
-
-        CookieService.removeHttpOnlyCookie("id_token", response);
-        CookieService.removeHttpOnlyCookie("refresh_token", response);
+        authenticationService.terminateSession(request, response, true);
 
         return ResponseEntity.ok("Logged out successfully");
     }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/model/User.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/model/User.java
@@ -1,4 +1,5 @@
 package com.kennan.mp3player.mp3_player_api.model;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -20,7 +21,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User implements UserDetails{
+public class User implements UserDetails {
     @Id
     private String id;
 
@@ -31,6 +32,9 @@ public class User implements UserDetails{
 
     @Builder.Default
     private String provider = null;
+
+    @Builder.Default
+    private int refreshVersion = 0;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/repository/UserRepository.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/repository/UserRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 import com.kennan.mp3player.mp3_player_api.model.User;
 
-public interface UserRepository extends MongoRepository<User, String>{
+public interface UserRepository extends MongoRepository<User, String>, UserRepositoryCustom {
     boolean existsByEmail(String email);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/repository/UserRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.kennan.mp3player.mp3_player_api.repository;
+
+public interface UserRepositoryCustom {
+    int incrementRefreshVersion(String email);
+}

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/repository/UserRepositoryCustomImpl.java
@@ -1,0 +1,35 @@
+package com.kennan.mp3player.mp3_player_api.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+import com.kennan.mp3player.mp3_player_api.model.User;
+
+@Repository
+public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Override
+    public int incrementRefreshVersion(String email) {
+        Query query = new Query(Criteria.where("email").is(email));
+        Update update = new Update().inc("refreshVersion", 1);
+
+        // Perform findAndModify
+        User user = mongoTemplate.findAndModify(
+                query,
+                update,
+                User.class);
+
+        if (user == null) {
+            throw new RuntimeException("User not found with email: " + email);
+        }
+
+        return user.getRefreshVersion();
+    }
+}

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
@@ -12,7 +12,6 @@ import com.kennan.mp3player.mp3_player_api.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
@@ -69,7 +69,7 @@ public class AuthenticationService {
         jwtService.blacklistToken(idToken);
         if (terminateRefresh) {
             String refreshToken = CookieService.getCookieValue(request, "refresh_token");
-            refreshTokenService.blacklistToken(refreshToken);
+            refreshTokenService.blacklistToken(idToken, refreshToken);
         }
 
         CookieService.removeHttpOnlyCookie("id_token", response);

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
@@ -9,52 +9,73 @@ import com.kennan.mp3player.mp3_player_api.exceptions.ExistingEmailException;
 import com.kennan.mp3player.mp3_player_api.model.User;
 import com.kennan.mp3player.mp3_player_api.repository.UserRepository;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 @Service
 public class AuthenticationService {
 
-
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
-    
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+
     public AuthenticationService(
-        UserRepository userRepository, 
-        PasswordEncoder passwordEncoder,
-        AuthenticationManager authenticationManager
-    ){
+            UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
+            AuthenticationManager authenticationManager,
+            JwtService jwtService,
+            RefreshTokenService refreshTokenService) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.authenticationManager = authenticationManager;
+        this.jwtService = jwtService;
+        this.refreshTokenService = refreshTokenService;
     }
 
     public User signup(RegisterUserDTO input) {
         if (userRepository.existsByEmail(input.getEmail())) {
             throw new ExistingEmailException();
         }
-        
+
         User user = User.builder()
-            .email(input.getEmail())
-            .name(input.getUsername())
-            .password(passwordEncoder.encode(input.getPassword()))
-            .provider(input.getProvider())
-            .build();
+                .email(input.getEmail())
+                .name(input.getUsername())
+                .password(passwordEncoder.encode(input.getPassword()))
+                .provider(input.getProvider())
+                .build();
 
         return userRepository.save(user);
     }
 
     public User authenticate(LoginUserDTO input) {
         authenticationManager.authenticate(
-            new UsernamePasswordAuthenticationToken(
-                input.getEmail(),
-                input.getPassword()
-            )
-        );
+                new UsernamePasswordAuthenticationToken(
+                        input.getEmail(),
+                        input.getPassword()));
 
         return userRepository.findByEmail(input.getEmail())
-            .orElseThrow();
+                .orElseThrow();
     }
-    
+
+    public void terminateSession(HttpServletRequest request, HttpServletResponse response, boolean terminateRefresh) {
+        String idToken = CookieService.getCookieValue(request, "id_token");
+
+        jwtService.blacklistToken(idToken);
+        if (terminateRefresh) {
+            String refreshToken = CookieService.getCookieValue(request, "refresh_token");
+            refreshTokenService.blacklistToken(refreshToken);
+        }
+
+        CookieService.removeHttpOnlyCookie("id_token", response);
+        if (terminateRefresh) {
+            CookieService.removeHttpOnlyCookie("refresh_token", response);
+        }
+    }
+
 }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationService.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 @Service
@@ -59,7 +60,7 @@ public class AuthenticationService {
                         input.getPassword()));
 
         return userRepository.findByEmail(input.getEmail())
-                .orElseThrow();
+                .orElseThrow(() -> new BadCredentialsException("Invalid username or password"));
     }
 
     public void terminateSession(HttpServletRequest request, HttpServletResponse response, boolean terminateRefresh) {

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/CookieService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/CookieService.java
@@ -28,4 +28,14 @@ public class CookieService {
 
         response.addCookie(cookie);
     }
+
+    public static void removeHttpOnlyCookie(String cookieName, HttpServletResponse response) {
+        Cookie cookie = new Cookie(cookieName, "");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+
+        response.addCookie(cookie);
+    }
 }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/CookieService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/CookieService.java
@@ -21,6 +21,8 @@ public class CookieService {
 
     public static void setHttpOnlyCookie(String token, String cookieName, HttpServletResponse response) {
         Cookie cookie = new Cookie(cookieName, token);
+        cookie.setDomain("localhost");
+        cookie.setAttribute("sameSite", "none");
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setPath("/");

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/JwtService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/JwtService.java
@@ -107,7 +107,7 @@ public class JwtService {
         }
         try {
             Jwt jwt = decodeToken(token);
-            String username = jwt.getClaim("sub");
+            String username = jwt.getClaim("email");
             return !isTokenExpired(token) && username.equals(userDetails.getUsername());
         } catch (Exception exception) {
             return false;

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/JwtService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/JwtService.java
@@ -39,10 +39,9 @@ public class JwtService {
     private static String BLACK_LIST_PREFIX = "blacklisted:";
 
     public JwtService(
-        NimbusJwtDecoder googleJwtDecoder, 
-        NimbusJwtDecoder jwtDecoder, 
-        RedisTemplate<String, String> redisTemplate
-    ) {
+            NimbusJwtDecoder googleJwtDecoder,
+            NimbusJwtDecoder jwtDecoder,
+            RedisTemplate<String, String> redisTemplate) {
         this.googleJwtDecoder = googleJwtDecoder;
         this.jwtDecoder = jwtDecoder;
         this.redisTemplate = redisTemplate;
@@ -51,22 +50,21 @@ public class JwtService {
     public String generateToken(UserDetails userDetails) {
         try {
             JWTClaimsSet claims = new JWTClaimsSet.Builder()
-                .subject(userDetails.getUsername())
-                .claim("email", userDetails.getUsername())
-                .expirationTime(new Date(System.currentTimeMillis() + jwtExpiration))
-                .issueTime(new Date(System.currentTimeMillis()))
-                .issuer(defaultIssuer)
-                .build();
+                    .subject(userDetails.getUsername())
+                    .claim("email", userDetails.getUsername())
+                    .expirationTime(new Date(System.currentTimeMillis() + jwtExpiration))
+                    .issueTime(new Date(System.currentTimeMillis()))
+                    .issuer(defaultIssuer)
+                    .build();
 
             SignedJWT signedJWT = new SignedJWT(
-                new JWSHeader(JWSAlgorithm.HS256), 
-                claims
-            );
+                    new JWSHeader(JWSAlgorithm.HS256),
+                    claims);
 
             JWSSigner signer = new MACSigner(secretKey);
             signedJWT.sign(signer);
             return signedJWT.serialize();
-        } catch(Exception exception) {
+        } catch (Exception exception) {
             throw new JwtException("Failed to generate JWT:" + exception.getMessage());
         }
     }
@@ -80,7 +78,7 @@ public class JwtService {
         }
     }
 
-    private String extractIssuer(String token) {
+    public String extractIssuer(String token) {
         try {
             String[] parts = token.split("\\.");
             if (parts.length < 2) {
@@ -111,7 +109,7 @@ public class JwtService {
             Jwt jwt = decodeToken(token);
             String username = jwt.getClaim("sub");
             return !isTokenExpired(token) && username.equals(userDetails.getUsername());
-        } catch(Exception exception) {
+        } catch (Exception exception) {
             return false;
         }
     }

--- a/src/main/java/com/kennan/mp3player/mp3_player_api/service/RefreshTokenService.java
+++ b/src/main/java/com/kennan/mp3player/mp3_player_api/service/RefreshTokenService.java
@@ -1,0 +1,163 @@
+package com.kennan.mp3player.mp3_player_api.service;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.kennan.mp3player.mp3_player_api.model.User;
+import com.kennan.mp3player.mp3_player_api.repository.UserRepository;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import io.jsonwebtoken.JwtException;
+
+@Service
+public class RefreshTokenService {
+    @Value("${issuer.name}")
+    private String defaultIssuer;
+
+    @Value("${refresh.secret.key}")
+    private String refreshSecret;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${google.token.url}")
+    private String tokenUrl;
+
+    private final NimbusJwtDecoder refreshDecoder;
+    private final JwtService jwtService;
+    private final RestTemplate restTemplate;
+    private final UserRepository userRepository;
+
+    public RefreshTokenService(NimbusJwtDecoder nimbusJwtDecoder, JwtService jwtService, RestTemplate restTemplate,
+            UserRepository userRepository) {
+        this.refreshDecoder = nimbusJwtDecoder;
+        this.jwtService = jwtService;
+        this.restTemplate = restTemplate;
+        this.userRepository = userRepository;
+    }
+
+    public String generateToken(User user) {
+        try {
+            JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                    .subject(user.getUsername())
+                    .claim("type", "refresh")
+                    .claim("version", user.getRefreshVersion())
+                    .issueTime(new Date(System.currentTimeMillis()))
+                    .issuer(defaultIssuer)
+                    .build();
+
+            SignedJWT signedJWT = new SignedJWT(
+                    new JWSHeader(JWSAlgorithm.HS256),
+                    claims);
+
+            JWSSigner signer = new MACSigner(refreshSecret);
+            signedJWT.sign(signer);
+            return signedJWT.serialize();
+        } catch (Exception exception) {
+            throw new JwtException("Failed to generate JWT:" + exception.getMessage());
+        }
+    }
+
+    private Jwt decodeToken(String token) {
+        return refreshDecoder.decode(token);
+    }
+
+    // validate token
+    private boolean isTokenValid(String token) {
+        Jwt refresh = decodeToken(token);
+        int refreshVersion = refresh.getClaim("version");
+
+        String email = refresh.getSubject();
+        try {
+            User user = userRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("User not found"));
+            if (user.getRefreshVersion() != refreshVersion) {
+                throw new RuntimeException(("Expired refresh token"));
+            }
+            return true;
+        } catch (RuntimeException e) {
+            System.out.println("Refresh Token invalid: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public String refreshIdToken(String idToken, String refreshToken) {
+        String issuer = jwtService.extractIssuer(idToken);
+        if ("https://accounts.google.com".equals(issuer)) {
+            return refreshGoogleToken(refreshToken);
+        } else if (isTokenValid(refreshToken)) {
+            return refreshCustomIdToken(refreshToken);
+        } else {
+            throw new RuntimeException("Invalid Refresh Token");
+        }
+    }
+
+    private String refreshCustomIdToken(String token) {
+        Jwt refresh = decodeToken(token);
+        UserDetails user = User.builder()
+                .email(refresh.getClaim("email")).build();
+        return jwtService.generateToken(user);
+    }
+
+    private String refreshGoogleToken(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("grant_type", "refresh_token");
+        body.add("refresh_token", token);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        try {
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    tokenUrl,
+                    HttpMethod.POST,
+                    request,
+                    new ParameterizedTypeReference<Map<String, Object>>() {
+                    });
+
+            Map<String, Object> responseBody = response.getBody();
+            if (responseBody == null || !responseBody.containsKey("id_token")) {
+                throw new IllegalArgumentException("Failed to obtain id_token from Google");
+            }
+
+            return (String) responseBody.get("id_token");
+
+        } catch (Exception e) {
+            throw new RuntimeException("Error refreshing Google token", e);
+        }
+    }
+
+    // needs google funct
+    public String blacklistToken(String token) {
+        Jwt refresh = decodeToken(token);
+        String email = refresh.getSubject();
+        userRepository.incrementRefreshVersion(email);
+        return token;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ server.port=8081
 spring.data.mongodb.uri=${MONGO_DB_CONNECTION_STRING}
 spring.data.mongodb.database=${DATABASE_NAME}
 
-spring.devtools.restart.enabled=false
+spring.devtools.restart.enabled=true
 
 jwt.secret.key=${JWT_SECRET_KEY}
 jwt.expiration=${JWT_EXPIRATION}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,6 @@ google.token.url = https://oauth2.googleapis.com/token
 
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.web=DEBUG
+
+spring.redis.host=${REDIS_HOST}
+spring.redis.port=${REDIS_PORT}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,12 +12,15 @@ spring.devtools.restart.enabled=false
 jwt.secret.key=${JWT_SECRET_KEY}
 jwt.expiration=${JWT_EXPIRATION}
 
+refresh.secret.key=${REFRESH_SECRET_KEY}
+
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 spring.security.oauth2.client.registration.google.scope=${GOOGLE_CLIENT_SCOPE}
 spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8081/auth/oauth/callback
 google.oauth.url = https://accounts.google.com/o/oauth2/v2/auth
 google.token.url = https://oauth2.googleapis.com/token
+google.token.revoke.url = https://oauth2.googleapis.com/revoke
 
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.web=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,5 +25,5 @@ google.token.revoke.url = https://oauth2.googleapis.com/revoke
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.web=DEBUG
 
-spring.redis.host=${REDIS_HOST}
-spring.redis.port=${REDIS_PORT}
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/configs/JwtDecoderConfigTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/configs/JwtDecoderConfigTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
 import com.kennan.mp3player.mp3_player_api.service.JwtService;
@@ -31,7 +32,11 @@ public class JwtDecoderConfigTest {
     }
 
     @Bean
-    public JwtService jwtService(NimbusJwtDecoder mockGoogleJwtDecoder, NimbusJwtDecoder jwtDecoder) {
-        return new JwtService(mockGoogleJwtDecoder, jwtDecoder);
+    public JwtService jwtService(
+        NimbusJwtDecoder mockGoogleJwtDecoder, 
+        NimbusJwtDecoder jwtDecoder, 
+        RedisTemplate<String, String> redisTemplate
+    ) {
+        return new JwtService(mockGoogleJwtDecoder, jwtDecoder, redisTemplate);
     }
 }

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/configs/JwtDecoderConfigTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/configs/JwtDecoderConfigTest.java
@@ -33,10 +33,9 @@ public class JwtDecoderConfigTest {
 
     @Bean
     public JwtService jwtService(
-        NimbusJwtDecoder mockGoogleJwtDecoder, 
-        NimbusJwtDecoder jwtDecoder, 
-        RedisTemplate<String, String> redisTemplate
-    ) {
+            NimbusJwtDecoder mockGoogleJwtDecoder,
+            NimbusJwtDecoder jwtDecoder,
+            RedisTemplate<String, String> redisTemplate) {
         return new JwtService(mockGoogleJwtDecoder, jwtDecoder, redisTemplate);
     }
 }

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
@@ -44,9 +44,6 @@ public class AuthenticationControllerTest {
     @Mock
     private RefreshTokenService refreshTokenService;
 
-    @Mock
-    private UserDetailsService userDetailsService;
-
     private AuthenticationController authenticationController;
     private RegisterUserDTO registerUserDTO;
     private LoginUserDTO loginUserDTO;
@@ -58,8 +55,7 @@ public class AuthenticationControllerTest {
                 jwtServiceMock,
                 authenticationServiceMock,
                 oAuthServiceMock,
-                refreshTokenService,
-                userDetailsService);
+                refreshTokenService);
         registerUserDTO = new RegisterUserDTO();
         registerUserDTO.setEmail("test@example.com");
         registerUserDTO.setPassword("password");

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UserDetailsService;
 
 import com.kennan.mp3player.mp3_player_api.dto.LoginUserDTO;
 import com.kennan.mp3player.mp3_player_api.dto.RegisterUserDTO;
@@ -25,6 +24,7 @@ import com.kennan.mp3player.mp3_player_api.service.JwtService;
 import com.kennan.mp3player.mp3_player_api.service.OAuthService;
 import com.kennan.mp3player.mp3_player_api.service.RefreshTokenService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @SpringBootTest
@@ -40,6 +40,9 @@ public class AuthenticationControllerTest {
 
     @Mock
     private HttpServletResponse httpServletResponseMock;
+
+    @Mock
+    private HttpServletRequest httpServletRequestMock;
 
     @Mock
     private RefreshTokenService refreshTokenService;
@@ -97,7 +100,8 @@ public class AuthenticationControllerTest {
     void testLoginExistingUserReturnsOk() {
         when(authenticationServiceMock.authenticate(loginUserDTO)).thenReturn(testUser);
 
-        ResponseEntity<User> response = authenticationController.authenticate(loginUserDTO, httpServletResponseMock);
+        ResponseEntity<User> response = authenticationController.authenticate(loginUserDTO, httpServletResponseMock,
+                httpServletRequestMock);
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -109,7 +113,7 @@ public class AuthenticationControllerTest {
         when(authenticationServiceMock.authenticate(loginUserDTO)).thenThrow(NoSuchElementException.class);
 
         assertThrows(NoSuchElementException.class, () -> {
-            authenticationController.authenticate(loginUserDTO, httpServletResponseMock);
+            authenticationController.authenticate(loginUserDTO, httpServletResponseMock, httpServletRequestMock);
         });
     }
 }

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 import com.kennan.mp3player.mp3_player_api.dto.LoginUserDTO;
 import com.kennan.mp3player.mp3_player_api.dto.RegisterUserDTO;
@@ -43,6 +44,9 @@ public class AuthenticationControllerTest {
     @Mock
     private RefreshTokenService refreshTokenService;
 
+    @Mock
+    private UserDetailsService userDetailsService;
+
     private AuthenticationController authenticationController;
     private RegisterUserDTO registerUserDTO;
     private LoginUserDTO loginUserDTO;
@@ -54,7 +58,8 @@ public class AuthenticationControllerTest {
                 jwtServiceMock,
                 authenticationServiceMock,
                 oAuthServiceMock,
-                refreshTokenService);
+                refreshTokenService,
+                userDetailsService);
         registerUserDTO = new RegisterUserDTO();
         registerUserDTO.setEmail("test@example.com");
         registerUserDTO.setPassword("password");

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
@@ -22,6 +22,7 @@ import com.kennan.mp3player.mp3_player_api.model.User;
 import com.kennan.mp3player.mp3_player_api.service.AuthenticationService;
 import com.kennan.mp3player.mp3_player_api.service.JwtService;
 import com.kennan.mp3player.mp3_player_api.service.OAuthService;
+import com.kennan.mp3player.mp3_player_api.service.RefreshTokenService;
 
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -30,7 +31,7 @@ public class AuthenticationControllerTest {
     @Mock
     private JwtService jwtServiceMock;
 
-    @Mock 
+    @Mock
     private AuthenticationService authenticationServiceMock;
 
     @Mock
@@ -38,6 +39,9 @@ public class AuthenticationControllerTest {
 
     @Mock
     private HttpServletResponse httpServletResponseMock;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     private AuthenticationController authenticationController;
     private RegisterUserDTO registerUserDTO;
@@ -47,10 +51,10 @@ public class AuthenticationControllerTest {
     @BeforeEach
     void setUp() {
         authenticationController = new AuthenticationController(
-            jwtServiceMock, 
-            authenticationServiceMock,
-            oAuthServiceMock
-        );
+                jwtServiceMock,
+                authenticationServiceMock,
+                oAuthServiceMock,
+                refreshTokenService);
         registerUserDTO = new RegisterUserDTO();
         registerUserDTO.setEmail("test@example.com");
         registerUserDTO.setPassword("password");
@@ -61,10 +65,10 @@ public class AuthenticationControllerTest {
         loginUserDTO.setPassword("password");
 
         testUser = User.builder()
-            .email("test@example.com")
-            .name("testUser")
-            .password("password")
-            .build();
+                .email("test@example.com")
+                .name("testUser")
+                .password("password")
+                .build();
     }
 
     @Test

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/controllers/AuthenticationControllerTest.java
@@ -25,6 +25,7 @@ import com.kennan.mp3player.mp3_player_api.service.JwtService;
 import com.kennan.mp3player.mp3_player_api.service.OAuthService;
 import com.kennan.mp3player.mp3_player_api.service.RefreshTokenService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 @SpringBootTest
@@ -40,6 +41,9 @@ public class AuthenticationControllerTest {
 
     @Mock
     private HttpServletResponse httpServletResponseMock;
+
+    @Mock
+    private HttpServletRequest httpServletRequestMock;
 
     @Mock
     private RefreshTokenService refreshTokenService;
@@ -97,7 +101,8 @@ public class AuthenticationControllerTest {
     void testLoginExistingUserReturnsOk() {
         when(authenticationServiceMock.authenticate(loginUserDTO)).thenReturn(testUser);
 
-        ResponseEntity<User> response = authenticationController.authenticate(loginUserDTO, httpServletResponseMock);
+        ResponseEntity<User> response = authenticationController.authenticate(loginUserDTO, httpServletResponseMock,
+                httpServletRequestMock);
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -109,7 +114,7 @@ public class AuthenticationControllerTest {
         when(authenticationServiceMock.authenticate(loginUserDTO)).thenThrow(NoSuchElementException.class);
 
         assertThrows(NoSuchElementException.class, () -> {
-            authenticationController.authenticate(loginUserDTO, httpServletResponseMock);
+            authenticationController.authenticate(loginUserDTO, httpServletResponseMock, httpServletRequestMock);
         });
     }
 }

--- a/src/test/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/kennan/mp3player/mp3_player_api/service/AuthenticationServiceTest.java
@@ -35,15 +35,18 @@ public class AuthenticationServiceTest {
     private PasswordEncoder passwordEncoderMock;
 
     @Mock
-    AuthenticationManager authenticationManagerMock;
+    private AuthenticationManager authenticationManagerMock;
+
+    @Mock
+    private RefreshTokenService refreshTokenServiceMock;
+
+    @Mock
+    private JwtService jwtService;
 
     @BeforeEach
     void setUp() {
-        this.authenticationService = new AuthenticationService(
-            userRepositoryMock, 
-            passwordEncoderMock, 
-            authenticationManagerMock
-        );
+        this.authenticationService = new AuthenticationService(userRepositoryMock, passwordEncoderMock,
+                authenticationManagerMock, jwtService, refreshTokenServiceMock);
     }
 
     @Test
@@ -88,9 +91,9 @@ public class AuthenticationServiceTest {
         assertEquals(returnedUser, result);
 
         verify(authenticationManagerMock, times(1))
-            .authenticate(any(UsernamePasswordAuthenticationToken.class));
+                .authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(userRepositoryMock, times(1))
-            .findByEmail("test@example.com");
+                .findByEmail("test@example.com");
     }
 
     @Test
@@ -105,8 +108,8 @@ public class AuthenticationServiceTest {
         });
 
         verify(authenticationManagerMock, times(1))
-            .authenticate(any(UsernamePasswordAuthenticationToken.class));
+                .authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(userRepositoryMock, times(1))
-            .findByEmail("test@example.com");
+                .findByEmail("test@example.com");
     }
 }


### PR DESCRIPTION
## `RefreshTokenService`
- Adds a method to generate a refresh token. Will not generate OAuth refresh tokens because the `/auth/oauth/authenticate` endpoint handles it
- Adds a method to generate a new Id token. Private methods will handle which type of ID token to regenerate (Custom or OAuth), this is determined by the `issuer` property in the JWT
- Adds a method to blacklist refresh tokens. The refresh token is blacklisted using refresh versions, where the current valid version of the refresh is to be stored in the database (cannot be placed in the cache because refresh tokens do not have an expiry date). Again, the type of refresh token will be handled automatically depending on custom or OAuth

## `RedisConfig`
- Creates a configuration with Beans to configure redis
- Redis is used to blacklist JWTs by placing the JWTs in the cache with a `blacklist` prefix and setting their TTL to the expiry of the JWT

## `AuthenticationController`
- `/auth/login` is modified to return a refresh HTTP only cookie as well
- `/auth/refresh` is added to refresh the ID token

## `LogoutController`
- `/logout` is added as a protected route (you must be logged in to log out). It blacklists the JWT and refresh tokens.
- `/me` is added to validate the JWT token (used by frontend middleware)